### PR TITLE
Prevent controllers mounted on vehicles from being rotated more than necessary

### DIFF
--- a/vehicles.js
+++ b/vehicles.js
@@ -594,7 +594,8 @@ class Vehicles {
 
         const tokenCentre = game.multilevel._getTokenCentre(vehicleScene, vt);
         const rDiff = relativeDiff(vehicleCentre, tokenCentre, diff);
-        if (vehicle.flags[VEHICLES.SCOPE].fixTokenOrientation) {
+        const flags = vehicle.flags[VEHICLES.SCOPE]
+        if (flags.fixTokenOrientation || (flags.controllerToken === vt.name)) {
           rDiff.r = 0;
         }
         if (vehicle.flags[VEHICLES.SCOPE].wallCollision) {


### PR DESCRIPTION
**The bug:** when a controller token is mounted on a vehicle and a player rotates it 15 degrees, the token will then be rotated an extra 15 degrees due to being captured and rotated by the vehicle itself.

**The solution:** prevent controller tokens from being rotated by their vehicles.

**IMPORTANT NOTE:** this might also make the mounted controller tokens not rotate if the vehicle rotates due to the drawing's Rotation field changing. My fix might need some patching to make the `if` statement more specific (e.g. to only handle cases when rotation is triggered by that same controller).